### PR TITLE
Fix #32

### DIFF
--- a/gdxmachine-core/src/main/kotlin/com/disgraded/gdxmachine/core/api/graphics/renderer/TextBumpRenderer.kt
+++ b/gdxmachine-core/src/main/kotlin/com/disgraded/gdxmachine/core/api/graphics/renderer/TextBumpRenderer.kt
@@ -29,8 +29,8 @@ class TextBumpRenderer : SpriteBatch(8191), Renderer {
 
     override fun draw(drawable: Drawable) {
         val text = drawable as Text
-        val oldProjectionMatrix = projectionMatrix
-        val projection = projectionMatrix.cpy()
+        val oldProjectionMatrix = projectionMatrix.cpy()
+        val projection = projectionMatrix
         projection.translate(text.x, text.y, 0f)
         projection.scale(text.scaleX, text.scaleY, 0f)
         projection.rotate(Vector3(0f, 0f, 1f), text.angle)

--- a/gdxmachine-core/src/main/kotlin/com/disgraded/gdxmachine/core/api/graphics/renderer/TextDiffuseRenderer.kt
+++ b/gdxmachine-core/src/main/kotlin/com/disgraded/gdxmachine/core/api/graphics/renderer/TextDiffuseRenderer.kt
@@ -29,8 +29,8 @@ class TextDiffuseRenderer : SpriteBatch(8191), Renderer {
 
     override fun draw(drawable: Drawable) {
         val text = drawable as Text
-        val oldProjectionMatrix = projectionMatrix
-        val projection = projectionMatrix.cpy()
+        val oldProjectionMatrix = projectionMatrix.cpy()
+        val projection = projectionMatrix
         projection.translate(text.x, text.y, 0f)
         projection.scale(text.scaleX, text.scaleY, 0f)
         projection.rotate(Vector3(0f, 0f, 1f), text.angle)


### PR DESCRIPTION
When drawing, the projection matrix was not correctly reset. Therefore, the second text was actually drawn, but outside the screen.